### PR TITLE
Update link to deposit-cli tool to create validator keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ https://ephemery.dev/ (add RPC with single click)
 ### Validators
 
 - [Launchpad](https://launchpad.ephemery.dev/)
-- https://github.com/remyroy/staking-deposit-cli/releases/tag/v2.3.0.ephemery CLI
+- [ethstaker-deposit-cli](https://github.com/remyroy/ethstaker-deposit-cli/releases/tag/v0.1-ephemery)
 
 ## Run a node
 


### PR DESCRIPTION
The old URL is dead because the repo was removed and replaced.